### PR TITLE
fix: use Ubuntu 22.04 for PHP 8.4 support in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     
     strategy:
       fail-fast: false
@@ -74,7 +74,7 @@ jobs:
 
   test-status:
     name: Test Status
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: test
     if: always()
     


### PR DESCRIPTION
Ubuntu 22.04 has better support for PHP 8.4 in GitHub Actions