### PR TITLE
Pass secrets and use coding standards in reusable CI workflow

### DIFF
--- a/.github/workflows/scheduled-ci.yml
+++ b/.github/workflows/scheduled-ci.yml
@@ -9,3 +9,6 @@ on:
 jobs:
   scheduled-ci:
     uses: builtnorth/.github/.github/workflows/composer-package-ci.yml@main
+    secrets: inherit
+    with:
+      composer-repository-profile: coding-standards-only

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,3 +9,5 @@ jobs:
   ci:
     uses: builtnorth/.github/.github/workflows/composer-package-ci.yml@main
     secrets: inherit
+    with:
+      composer-repository-profile: coding-standards-only

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,3 +8,4 @@ on:
 jobs:
   ci:
     uses: builtnorth/.github/.github/workflows/composer-package-ci.yml@main
+    secrets: inherit


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration for CI jobs. The main change is to pass the `composer-repository-profile` input and inherit secrets for both the scheduled and regular CI workflows. This ensures that the workflows use the correct Composer repository profile and have access to necessary secrets.

Workflow configuration updates:

* Both `.github/workflows/scheduled-ci.yml` and `.github/workflows/tests.yml` now pass `composer-repository-profile: coding-standards-only` to the reusable workflow. [[1]](diffhunk://#diff-4c393c7d06debaaf9ae6cdc9d3eadc35eb6bf57c307d23cbe8ecdfadc34c3e84R12-R14) [[2]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR11-R13)
* Both workflows now explicitly inherit secrets by adding `secrets: inherit` to the job configuration. [[1]](diffhunk://#diff-4c393c7d06debaaf9ae6cdc9d3eadc35eb6bf57c307d23cbe8ecdfadc34c3e84R12-R14) [[2]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR11-R13)